### PR TITLE
Drop support for PHP 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-- 5.6
 - 7.2
 before_script:
 - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ]
   },
   "require": {
-    "php": ">=5.6.0"
+    "php": ">=7.2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "*",

--- a/test/AuthenticateTest.php
+++ b/test/AuthenticateTest.php
@@ -2,7 +2,7 @@
 
 class CastleAuthenticateTest extends Castle_TestCase
 {
-  public function tearDown()
+  public function tearDown(): void
   {
     Castle_RequestTransport::reset();
     Castle_RequestTransport::setResponse(200, '');

--- a/test/Castle.php
+++ b/test/Castle.php
@@ -2,7 +2,7 @@
 
 abstract class Castle_TestCase extends \PHPUnit\Framework\TestCase
 {
-  public function setUp()
+  public function setUp(): void
   {
     Castle::setApiKey('secret');
   }

--- a/test/CastleTest.php
+++ b/test/CastleTest.php
@@ -4,11 +4,11 @@ class CastleTest extends Castle_TestCase
 {
   protected $sessionToken;
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     Castle::setApiKey('secretkey');
   }
 
-  public function setUp()
+  public function setUp(): void
   {
     $_SESSION = array();
     $_COOKIE = array();

--- a/test/ErrorsTest.php
+++ b/test/ErrorsTest.php
@@ -3,7 +3,7 @@
 class CastleErrorTest extends Castle_TestCase
 {
 
-  public function setUp()
+  public function setUp(): void
   {
     $_SERVER['HTTP_USER_AGENT'] = 'TestAgent';
     $_SERVER['REMOTE_ADDR'] = '8.8.8.8';

--- a/test/ModelTest.php
+++ b/test/ModelTest.php
@@ -26,13 +26,13 @@ class TestShoe extends TestModel
 
 class CastleModelTest extends Castle_TestCase
 {
-  public static function setUpBeforeClass()
+  public static function setUpBeforeClass(): void
   {
     $_SERVER['HTTP_USER_AGENT'] = 'TestAgent';
     $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
   }
 
-  public function tearDown()
+  public function tearDown(): void
   {
     Castle_RequestTransport::reset();
   }

--- a/test/RequestContextTest.php
+++ b/test/RequestContextTest.php
@@ -3,13 +3,13 @@
 class CastleRequestContextTest extends \Castle_TestCase
 {
 
-  public static function setUpBeforeClass() {
+  public static function setUpBeforeClass(): void {
     $_SERVER['HTTP_USER_AGENT'] = 'TestAgent';
     $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
     unset($_SERVER['HTTP_X_FORWARDED_FOR']);
   }
 
-  public function setUp() {
+  public function setUp(): void {
     $_COOKIE = array();
   }
 

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -3,7 +3,7 @@
 class CastleRequestTest extends \Castle_TestCase
 {
 
-  public static function setUpBeforeClass()
+  public static function setUpBeforeClass(): void
   {
     $_SERVER['HTTP_USER_AGENT'] = 'TestAgent';
     $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
@@ -12,13 +12,13 @@ class CastleRequestTest extends \Castle_TestCase
     Castle::setUseWhitelist(false);
   }
 
-  public function setUp()
+  public function setUp(): void
   {
     $_COOKIE = array();
     $_SESSION = array();
   }
 
-  public function tearDown()
+  public function tearDown(): void
   {
     Castle_RequestTransport::setResponse();
   }


### PR DESCRIPTION
PHP5 reached of life early this year and this enables us to comply with PHP7 requirements