### PR TITLE
Added Castle_InvalidRequestTokenError

### DIFF
--- a/lib/Castle/Errors.php
+++ b/lib/Castle/Errors.php
@@ -54,3 +54,8 @@ class Castle_InvalidParametersError extends Castle_ApiError
 {
 
 }
+
+class Castle_InvalidRequestTokenError extends Castle_InvalidParametersError
+{
+
+}

--- a/lib/Castle/Request.php
+++ b/lib/Castle/Request.php
@@ -27,7 +27,13 @@ class Castle_Request
       case 404:
         throw new Castle_NotFoundError($msg, $type, $status);
       case 422:
-        throw new Castle_InvalidParametersError($msg, $type, $status);
+        // Handle subtype errors
+        switch($type) {
+          case 'invalid_request_token':
+            throw new Castle_InvalidRequestTokenError($msg, $type, $status);
+          default:
+            throw new Castle_InvalidParametersError($msg, $type, $status);
+        }
       default:
         throw new Castle_ApiError($msg, $type, $status);
     }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -78,4 +78,14 @@ class CastleRequestTest extends \Castle_TestCase
     $this->expectException(Castle_InvalidParametersError::class);
     $req->send('GET', '/users');
   }
+
+  public function testInvalidRequestTokenRequest()
+  {
+    Castle_RequestTransport::setResponse(
+      422, '{ "type": "invalid_request_token", "message": "" }'
+    );
+    $req = new Castle_Request();
+    $this->expectException(Castle_InvalidRequestTokenError::class);
+    $req->send('POST', '/risk');
+  }
 }


### PR DESCRIPTION
Allow better handling of request token related errors

```php
try {
  Castle::risk([]);
} catch (Castle_InvalidRequestTokenError $e) {
  // Block request due to missing or invalid client token
} catch (Castle_InvalidParametersError $e) {
  // Fix integration errors
}
```